### PR TITLE
Support for multiple VPNs on the vpn mode using XPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Nagios-style checks against Solace Message Routers using SEMPv1 protocol. Design
 
     Usage: check_solace.pl -H host -V version -m mode [ -p port ] [ -u username ] [ -P password ]
        [ -n name ] [ -v vpn ] [ -t ] [ -D ] [ -w warning ] [ -c critical ]
-       [ -y type ]
+       [ -rw warning ] [ -rc critical ] [ -y type ]
 
     Returns with an exit code of 0 (success), 1 (warning), 2 (critical), or 3 (unknown)
     This is version 0.08.
@@ -34,6 +34,8 @@ Nagios-style checks against Solace Message Routers using SEMPv1 protocol. Design
     Limit options:
       -w value, --warning=value   the warning threshold, range depends on the action
       -c value, --critical=value  the critical threshold, range depends on the action
+      -rw value, --rwarning=value   the warning threshold, specific for rates when another value is already present
+      -rc value, --rcritical=value  the critical threshold, specific for rates when another value is already present
 
     Modes:
       redundancy
@@ -66,6 +68,9 @@ Check message VPN quota usage and statistics:
 
     ./check_solace.pl -H <...> --port=8080 --password=<...> --version=7.2 --mode=vpn --name=<my_vpn> --warning=50 --critical=95
     OK. Subscriptions 16/500000, Connections 10/1000 | 'unique-subscriptions'=16 'subscriptions-usage'=0.00%;50;95 'connections'=10 'conn-usage'=0.01%;50;95 'conn-smf'=10 'conn-web'=0 'conn-mqtt'=0 'ingress-rate'=123 'egress-rate'=0 'ingress-byte-rate'=24439 'egress-byte-rate'=0 'ingress-discards'=51500040 'egress-discards'=19
+
+    ./check_solace.pl -H <...> --port=8080 --password=<...> --version=7.2 --mode=vpn --name=prod* --warning=50 --critical=95 --rwarning=10000 --rcritical=15000
+    CRITICAL prod_vpn0 Enabled: false, Operational: false, Status: Down;|'prod_vpn1-unique-subscriptions'=6 'prod_vpn1-subscriptions-usage'=0.00%;70;90 'prod_vpn1-connections'=1 'prod_vpn1-conn-usage'=0.00%;70;90 'prod_vpn1-conn-smf'=1 'prod_vpn1-conn-web'=0 'prod_vpn1-conn-mqtt'=0 'prod_vpn1-ingress-rate'=0;10000;15000 'prod_vpn1-egress-rate'=0;10000;15000 'prod_vpn1-ingress-byte-rate'=0 'prod_vpn1-egress-byte-rate'=0 'prod_vpn1-ingress-discards'=0 'prod_vpn1-egress-discards'=0 'prod_vpn1-spool-egress-discards'=0 'prod_vpn2-unique-subscriptions'=56 'prod_vpn2-subscriptions-usage'=0.00%;70;90 'prod_vpn2-connections'=51 'prod_vpn2-conn-usage'=0.01%;70;90 'prod_vpn2-conn-smf'=51 'prod_vpn2-conn-web'=0 'prod_vpn2-conn-mqtt'=0 'prod_vpn2-ingress-rate'=0;10000;15000 'prod_vpn2-egress-rate'=0;10000;15000 'prod_vpn2-ingress-byte-rate'=25 'prod_vpn2-egress-byte-rate'=25 'prod_vpn2-ingress-discards'=0 'prod_vpn2-egress-discards'=26 'prod_vpn2-spool-egress-discards'=26 'prod_vpn3-unique-subscriptions'=38 'prod_vpn3-subscriptions-usage'=0.00%;70;90 'prod_vpn3-connections'=29 'prod_vpn3-conn-usage'=0.00%;70;90 'prod_vpn3-conn-smf'=29 'prod_vpn3-conn-web'=0 'prod_vpn3-conn-mqtt'=0 'prod_vpn3-ingress-rate'=0;10000;15000 'prod_vpn3-egress-rate'=0;10000;15000 'prod_vpn3-ingress-byte-rate'=0 'prod_vpn3-egress-byte-rate'=0 'prod_vpn3-ingress-discards'=0 'prod_vpn3-egress-discards'=0 'prod_vpn3-spool-egress-discards'=0 'prod_vpn4-unique-subscriptions'=38 'prod_vpn4-subscriptions-usage'=0.00%;70;90 'prod_vpn4-connections'=33 'prod_vpn4-conn-usage'=0.00%;70;90 'prod_vpn4-conn-smf'=33 'prod_vpn4-conn-web'=0 'prod_vpn4-conn-mqtt'=0 'prod_vpn4-ingress-rate'=0;10000;15000 'prod_vpn4-egress-rate'=11;10000;15000 'prod_vpn4-ingress-byte-rate'=16 'prod_vpn4-egress-byte-rate'=6346 'prod_vpn4-ingress-discards'=0 'prod_vpn4-egress-discards'=228218881 'prod_vpn4-spool-egress-discards'=41464
 
 Check memory usage:
 

--- a/check_solace.pl
+++ b/check_solace.pl
@@ -5,7 +5,7 @@
 #
 # Vitaly Agapov <v.agapov@quotix.com>
 # 2017/02/27
-# Last modified: 2019/11/25
+# Last modified: 2019/12/09
 ##########################
 
 use strict;
@@ -15,6 +15,7 @@ use Data::Dumper qw/Dumper/;
 use File::Basename qw/basename dirname/;
 use lib dirname(__FILE__);
 use Solace::SEMP;
+use XML::LibXML;
 
 our $VERSION = '0.09';
 our %CODE=( OK => 0, WARNING => 1, CRITICAL => 2, UNKNOWN => 3 );
@@ -27,6 +28,8 @@ GetOptions(
     'help|h',
     'warning|w=s',
     'critical|c=s',
+    'rwarning|rw=s',
+    'rcritical|rc=s',
     'version|V=s',
     'mode|m=s',
     'vpn|v=s',
@@ -443,6 +446,8 @@ elsif ($opt{mode} eq 'client-username') {
 elsif ($opt{mode} eq 'vpn') {
     $opt{warning} ||= 50;
     $opt{critical} ||= 95;
+    $opt{rwarning} ||= 10000;
+    $opt{rcritical} ||= 15000;
 
     $opt{vpn} ||= $opt{name};
 
@@ -453,53 +458,71 @@ elsif ($opt{mode} eq 'vpn') {
 
     my $req = $semp->getMessageVpnStats(name => $opt{vpn});
     if (! $req->{error} ) {
-        my $enabled = $req->{result}->{enabled}->[0];
-        my $operational = $req->{result}->{operational}->[0];
-        my $status = $req->{result}->{'local-status'}->[0];
-        my $uniqueSubscriptions = $req->{result}->{'unique-subscriptions'}->[0];
-        my $maxSubscriptions = $req->{result}->{'max-subscriptions'}->[0];
-        my $connections = $req->{result}->{'connections'}->[0];
-        my $maxConnections = $req->{result}->{'max-connections'}->[0];
-        my $connSMF = $req->{result}->{'connections-service-smf'}->[0];
-        my $connWEB = $req->{result}->{'connections-service-web'}->[0];
-        my $connMQTT = $req->{result}->{'connections-service-mqtt'}->[0];
-        my $ingressRate = $req->{result}->{'average-ingress-rate-per-minute'}->[0];
-        my $egressRate = $req->{result}->{'average-egress-rate-per-minute'}->[0];
-        my $ingressByteRate = $req->{result}->{'average-ingress-byte-rate-per-minute'}->[0];
-        my $egressByteRate = $req->{result}->{'average-egress-byte-rate-per-minute'}->[0];
-        my $ingressDiscards = $req->{result}->{'total-ingress-discards'}->[0];
-        my $egressDiscards = $req->{result}->{'total-egress-discards'}->[0];
+        my $output = '';
+        my $perf;
+        # Its easier to get enabled value in bulk using XPath
+        # In the former way we get the last value from the last enabled key
+        # <kerberos-auth>
+        #      <enabled>false</enabled>
+        my $dom = XML::LibXML->load_xml(string => $req->{raw});
 
-        if (! defined $enabled) {
-            print "Message VPN $opt{name} not known\n";
-            exit $CODE{CRITICAL};
-        }
+        # /rpc-reply/rpc/show/message-vpn/vpn
+        foreach my $vpn ($dom->findnodes('//vpn')) {
+            my $name =  $vpn->findvalue('./name');
+            my $enabled = $vpn->findvalue('./enabled');
+            my $operational = $vpn->findvalue('./operational');
+            my $status = $vpn->findvalue('./local-status');
+ 
+            if ($enabled eq 'true' && $operational eq 'true' && $status eq 'Up') {
+                my $uniqueSubscriptions =  $vpn->findvalue('./unique-subscriptions');
+                my $maxSubscriptions =  $vpn->findvalue('./max-subscriptions');
+                my $maxConnections =  $vpn->findvalue('./max-connections');
+                my $connSMF =  $vpn->findvalue('./connections-service-smf');
+                my $connWEB =  $vpn->findvalue('./connections-service-web');
+                my $connMQTT =  $vpn->findvalue('./connections-service-mqtt');
+                my $ingressByteRate =  $vpn->findvalue('./stats/average-ingress-byte-rate-per-minute');
+                my $egressByteRate =  $vpn->findvalue('./stats/average-egress-byte-rate-per-minute');
+                my $connections =  $vpn->findvalue('./connections');
+                my $ingressRate =  $vpn->findvalue('./stats/average-ingress-rate-per-minute');
+                my $egressRate =  $vpn->findvalue('./stats/average-egress-rate-per-minute');
+                my $ingressDiscards =  $vpn->findvalue('./stats/ingress-discards/total-ingress-discards');
+                my $egressDiscards =  $vpn->findvalue('./stats/egress-discards/total-egress-discards');
 
-        if ($enabled eq 'true' && $operational eq 'true' && $status eq 'Up') {
-            my $connUsage = 0;
-            if ($maxConnections > 0) {
-                $connUsage = sprintf("%.2f",$connections / $maxConnections);
-            }
-            my $subscrUsage = 0;
-            if ($maxSubscriptions > 0) {
-                $subscrUsage = sprintf("%.2f",$uniqueSubscriptions / $maxSubscriptions);
-            }
-            if ($connUsage >= $opt{critical} || $subscrUsage >= $opt{critical}) {
+                # Metric to monitor recommended by Solace Co.
+                my $spoolEgressDiscards =  $vpn->findvalue('./stats/egress-discards/msg-spool-egress-discards');
+                my $connUsage = 0;
+                if ($maxConnections > 0) {
+                    $connUsage = sprintf("%.2f",$connections / $maxConnections);
+                }
+                my $subscrUsage = 0;
+                if ($maxSubscriptions > 0) {
+                    $subscrUsage = sprintf("%.2f",$uniqueSubscriptions / $maxSubscriptions);
+                }
+                # Only issues will be shown in Output giving preference to perfdata
+                if ($connUsage >= $opt{critical} || $subscrUsage >= $opt{critical} || $ingressRate >= $opt{rcritical} || $egressRate >= $opt{rcritical}) {
+                    $exitStatus = $CODE{CRITICAL};
+                    $output .=  "$name-Subs $uniqueSubscriptions/$maxSubscriptions, $name-Conns $connections/$maxConnections ".
+                    "$name-Ingress-Rate $ingressRate;$opt{rwarning};$opt{rcritical}, $name-Egress-Rate $egressRate;$opt{rwarning};$opt{rcritical} ";
+                } elsif ($connUsage >= $opt{warning} || $subscrUsage >= $opt{warning} || $ingressRate >= $opt{rwarning} || $egressRate >= $opt{rwarning}) {
+                    $exitStatus = $CODE{WARNING};
+                    $output .=  "$name-Subs $uniqueSubscriptions/$maxSubscriptions, $name-Conns $connections/$maxConnections ".
+                    "$name-Ingress-Rate $ingressRate;$opt{rwarning};$opt{rcritical}, $name-Egress-Rate $egressRate;$opt{rwarning};$opt{rcritical} ";
+                }
+                $perf .=    "'$name-unique-subscriptions'=$uniqueSubscriptions ".
+                            "'$name-subscriptions-usage'=$subscrUsage%;$opt{warning};$opt{critical} '$name-connections'=$connections ".
+                            "'$name-conn-usage'=$connUsage%;$opt{warning};$opt{critical} ".
+                            "'$name-conn-smf'=$connSMF '$name-conn-web'=$connWEB '$name-conn-mqtt'=$connMQTT ".
+                            "'$name-ingress-rate'=$ingressRate;$opt{rwarning};$opt{rcritical} '$name-egress-rate'=$egressRate;$opt{rwarning};$opt{rcritical} ".
+                            "'$name-ingress-byte-rate'=$ingressByteRate '$name-egress-byte-rate'=$egressByteRate '$name-ingress-discards'=$ingressDiscards ".
+                            "'$name-egress-discards'=$egressDiscards '$name-spool-egress-discards'=$spoolEgressDiscards ";
+            } else {
+                # VPN with issues
                 $exitStatus = $CODE{CRITICAL};
-            } elsif ($connUsage >= $opt{warning} || $subscrUsage >= $opt{warning}) {
-                $exitStatus = $CODE{WARNING};
+                $output .= " $name Enabled: $enabled, Operational: $operational, Status: $status;";   
             }
-            print $ERROR{$exitStatus}.". Subscriptions $uniqueSubscriptions/$maxSubscriptions, ".
-            "Connections $connections/$maxConnections | 'unique-subscriptions'=$uniqueSubscriptions ".
-            "'subscriptions-usage'=$subscrUsage%;$opt{warning};$opt{critical} 'connections'=$connections ".
-            "'conn-usage'=$connUsage%;$opt{warning};$opt{critical} ".
-            "'conn-smf'=$connSMF 'conn-web'=$connWEB 'conn-mqtt'=$connMQTT ".
-            "'ingress-rate'=$ingressRate 'egress-rate'=$egressRate 'ingress-byte-rate'=$ingressByteRate ".
-            "'egress-byte-rate'=$egressByteRate 'ingress-discards'=$ingressDiscards 'egress-discards'=$egressDiscards\n";
-        } else {
-            print "CRITICAL. Enabled: $enabled, Operational: $operational, Status: $status\n";
-            exit $CODE{CRITICAL};
         }
+        print $ERROR{$exitStatus}." ".$output."|".$perf."\n";
+        exit $exitStatus;
     } else {
         fail($req->{error});
     }
@@ -519,8 +542,6 @@ elsif ($opt{mode} eq 'spool') {
     if (! $req->{error} ) {
         my $c = -1;
         my %values;
-#        my @mandatoryStats = ('current-spool-usage-mb', 'current-messages-spooled', 'maximum-spool-usage-mb');
-#        my @optionalStats = ('maximum-queues-and-topic-endpoints', 'current-queues-and-topic-endpoints', 'maximum-egress-flows', 'current-egress-flows', 'maximum-ingress-flows', 'current-ingress-flows', 'maximum-transactions', 'current-transactions', 'maximum-transacted-sessions', 'current-transacted-sessions');
         my @stats = ('current-spool-usage-mb', 'current-messages-spooled', 'maximum-spool-usage-mb', 'maximum-queues-and-topic-endpoints', 'current-queues-and-topic-endpoints', 'maximum-egress-flows', 'current-egress-flows', 'maximum-ingress-flows', 'current-ingress-flows', 'maximum-transactions', 'current-transactions', 'maximum-transacted-sessions', 'current-transacted-sessions');
         my $crit = '';
         my $output;
@@ -695,7 +716,8 @@ sub help {
     my $me = basename($0);
     print qq{Usage: $me -H host -V version -m mode [ -p port ] [ -u username ]
                         [ -P password ] [ -v vpn ] [ -n name ] [ -t ] [ -D ]
-                        [ -w warning ] [ -c critical ] [ -y type ]
+                        [ -w warning ] [ -c critical ] [ -rw rwarning ] [ -rc rcritical ]
+                        [ -y type ]
 
 Run checks against Solace Message Router using SEMP protocol.
 Returns with an exit code of 0 (success), 1 (warning), 2 (critical), or 3 (unknown)
@@ -717,6 +739,8 @@ Common connection options:
 Limit options:
   -w value, --warning=value   the warning threshold, range depends on the action
   -c value, --critical=value  the critical threshold, range depends on the action
+  -rw value, --rwarning=value   the warning threshold, specific for rates when another value is already present
+  -rc value, --rcritical=value  the critical threshold, specific for rates when another value is already present
 
 Modes:
   redundancy


### PR DESCRIPTION
Hi Vitaly,

I added a dependency and refactored the vpn mode, this because one of our use cases is to get the metrics from a segment of vpns automatically using the plugin instead of Icinga configuration and we need to alert based on rates as well.
There were some issues trying to get the < enabled > key since Solace has 5 per VPN, it was easier for me to refactor that part using XPath and get the data directly from the XML.
Tried not no break too much stuff and hope it works for you.
Also, I will destroy my fork and work directly with your branch if you agree... new policy at the company :D

Have a nice day.
